### PR TITLE
Added check for whitespace characters in ft_atoi.c

### DIFF
--- a/mini-moul/tests/C04/ex03/ft_atoi.c
+++ b/mini-moul/tests/C04/ex03/ft_atoi.c
@@ -151,6 +151,11 @@ int main(void)
             .input = "1 2 3 4 5 6 7 8 9 0 a b c d e f g h i j k l m n o p q r s t u v w x y z",
             .expected = 1,
         },
+        {
+            .desc = "Convert string with whitespace characters",
+            .input = "\f \n \r \t \v 123",
+            .expected = 123,
+	}
     };
     int count = sizeof(tests) / sizeof(tests[0]);
 


### PR DESCRIPTION
I added check for additional whitespace characters defined by isspace(3), since the exercise states:

_The string can start with an arbitray amount of whitespace (as determined by isspace(3))._

Those characters are: `\f` `\n` `\r` `\t` `\v`, space character also included.