### PR TITLE
Fix on test C03 ex05

### DIFF
--- a/mini-moul/tests/C03/ex05/ft_strlcat.c
+++ b/mini-moul/tests/C03/ex05/ft_strlcat.c
@@ -66,7 +66,7 @@ int run_tests(t_test *tests, int count)
 
     for (i = 0; i < count; i++)
     {
-        char dest[strlen(tests[i].dest) + 1];
+        char *dest = malloc(strlen(tests[i].dest) + 1);
         strcpy(dest, tests[i].dest);
 
         ft_strlcat(dest, tests[i].src, tests[i].size);
@@ -80,6 +80,7 @@ int run_tests(t_test *tests, int count)
         {
             printf("  " GREEN CHECKMARK GREY " [%d] %s Expected \"%s\" output \"%s\"\n" DEFAULT, i + 1, tests[i].desc, tests[i].expected_output, dest);
         }
+        free(dest);
     }
 
     return error;


### PR DESCRIPTION
Mini was having trouble running the tests on C03 ex05
Changed line 57 to 
        char *dest = malloc(strlen(tests[i].dest) + 1);
and added
free(dest) at the end of the function.

This should allocate enough space for the string stored in tests[i].dest .