### PR TITLE
C03/ex05: Allocate at least `size` bytes for `dest`

### DIFF
--- a/mini-moul/tests/C03/ex05/ft_strlcat.c
+++ b/mini-moul/tests/C03/ex05/ft_strlcat.c
@@ -66,7 +66,7 @@ int run_tests(t_test *tests, int count)
 
     for (i = 0; i < count; i++)
     {
-        char dest[strlen(tests[i].dest) + 1];
+        char dest[tests[i].size + 1];
         strcpy(dest, tests[i].dest);
 
         ft_strlcat(dest, tests[i].src, tests[i].size);


### PR DESCRIPTION
`strlcat` assumes dest has *at least* `size` bytes allocated. Allocating `strlen(test.dest)` would lead to valid implementations segfaulting when `size` > `strlen(test.dest) + 1`